### PR TITLE
Implement ordering of kiwi repos

### DIFF
--- a/kiwi_import
+++ b/kiwi_import
@@ -1,6 +1,7 @@
 #!/usr/bin/env ruby
 require 'fileutils'
 require 'optparse'
+require 'net/https'
 
 options = {}
 OptionParser.new do |opts|
@@ -33,6 +34,31 @@ def rename_kiwi_config(outdir)
   File.rename(File.join(outdir, 'config.xml'), File.join(outdir, 'config.kiwi'))
 end
 
+def order_kiwi_repos(outdir)
+  api_url = ENV["OBS_SERVICE_APIURL"]
+
+  unless api_url
+    abort("No API url defined. This might be caused by using an older osc version.")
+  end
+
+  kiwi_config = File.join(outdir, 'config.kiwi')
+  uri = URI.parse(api_url)
+
+  https = Net::HTTP.new(uri.host, uri.port)
+  https.use_ssl = (uri.scheme == "https")
+
+  request = Net::HTTP::Post.new("/source?cmd=orderkiwirepos")
+  request.body = File.read(kiwi_config)
+  request.content_type = "text/xml"
+
+  response = https.request(request)
+  if response.code.to_i == 200
+    File.write(kiwi_config, response.body)
+  else
+    abort("Ordering kiwi repositories failed. Backend responded with '#{response.code} - #{response.message}'")
+  end
+end
+
 current_path = Dir.pwd
 outdir = options[:outdir]
 unless File.directory?(outdir) || File.exist?(outdir)
@@ -43,4 +69,5 @@ kiwi_archive = get_kiwi_archive(current_path)
 extract_archive(kiwi_archive, outdir)
 create_root_archive(outdir)
 rename_kiwi_config(outdir)
+order_kiwi_repos(outdir)
 


### PR DESCRIPTION
Kiwi configurations created by SUSE Studio all have the same priority. This was
causing build failures when importing such configs to OBS. Thus the OBS backend
provides a way to order repositories of a kiwi configuration file in a OBS
friendly way.