### PR TITLE
Fix RepositoryReplacer for SLES

### DIFF
--- a/KiwiImport/lib/repository_replacer.rb
+++ b/KiwiImport/lib/repository_replacer.rb
@@ -3,7 +3,7 @@ class RepositoryReplacer
 
   def initialize(config, repository_map)
     self.config = config
-    self.repository_map = repository_map
+    self.repository_map = repository_map || []
   end
 
   def replace!

--- a/kiwi_import
+++ b/kiwi_import
@@ -37,8 +37,8 @@ end
 kiwi_archive_path = KiwiArchiveFinder.new.archive
 kiwi_archive = KiwiArchive.new(kiwi_archive_path, outdir).create_import!
 if kiwi_archive.is_sle?
-  kiwi_archive.config = RepositoryReplacer.new(kiwi_archive.config, config[:sle_repositories]).replace!
-  kiwi_archive.config = RepositoryAppender.new(kiwi_archive.config, config[:sle_dependencies_repository]).append!
+  kiwi_archive.config = RepositoryReplacer.new(kiwi_archive.config, config["sle_repositories"]).replace!
+  kiwi_archive.config = RepositoryAppender.new(kiwi_archive.config, config["sle_dependencies_repository"]).append!
 end
 
 # We use osc locally as workaround because '/source?cmd=orderkiwirepos'

--- a/spec/repository_replacer_spec.rb
+++ b/spec/repository_replacer_spec.rb
@@ -15,6 +15,12 @@ RSpec.describe RepositoryReplacer do
           replacer.replace!
         }.to change { replacer.config.strip }.from(input).to(output)
       end
+
+    it 'does not crash when repository map is nil' do
+        expect {
+          RepositoryReplacer.new(input, nil).replace!
+        }.not_to raise_exception
+      end
     end
   end
 end


### PR DESCRIPTION
- Accessing repository map from config did not work
- RepositoryReplacer crashed when map was nil
Fix #14.