### PR TITLE
Use UTF-8 encoding

### DIFF
--- a/KiwiImport/lib/kiwi_archive.rb
+++ b/KiwiImport/lib/kiwi_archive.rb
@@ -18,7 +18,7 @@ class KiwiArchive
 
   def config
     if extracted?
-      File.read(config_path).to_s
+      File.read(config_path, encoding: "utf-8").to_s
     else
       raise 'KiwiArchive not extracted yet. Use #create_import! first.'
     end


### PR DESCRIPTION
as the docker container has no locale installed and it failed with invalid byte sequence error.