### PR TITLE
basic auth for http_repository_orderer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: ruby
-rvm: 2.4.1
+rvm: 2.5.8
 script:
   - bundle exec rspec
 cache: bundler

--- a/KiwiImport/lib/http_repository_orderer.rb
+++ b/KiwiImport/lib/http_repository_orderer.rb
@@ -33,12 +33,14 @@ class HttpRepositoryOrderer
 
   def send_order_request(url)
     uri = URI.parse(url)
-
     https = Net::HTTP.new(uri.host, uri.port)
     https.use_ssl = (uri.scheme == "https")
     https.set_debug_output($stdout) if options[:verbose]
 
     request = Net::HTTP::Post.new("/source?cmd=orderkiwirepos")
+    if ENV.key?('OBS_SERVICE_USER')
+       request.basic_auth(ENV['OBS_SERVICE_USER'], ENV['OBS_SERVICE_PASS'])
+    end
     request.body = config
     request.content_type = "text/xml"
 


### PR DESCRIPTION
This patch adds the possibilty to specify a user/password combination
in ENV to use for basic auth at the API server (specified in api_url).

Without this patch the service fails with '401 - Unauthorized' when using
e.g. 'https://build.opensuse.org' as api url.